### PR TITLE
return clear  Msg

### DIFF
--- a/hdw-common/src/main/java/com/hdw/common/result/CommonResult.java
+++ b/hdw-common/src/main/java/com/hdw/common/result/CommonResult.java
@@ -131,7 +131,8 @@ public class CommonResult<T> implements Serializable {
     }
 
     public CommonResult msg(String message) {
-        this.msg = i18n(ErrorCode.getHttpCode(this.code).getMsg(), message);
+        //this.msg = i18n(ErrorCode.getHttpCode(this.code).getMsg(), message);
+        this.msg = message;
         return this;
     }
 


### PR DESCRIPTION
Always  return Enum 500 code match Msg "操作失败",no one know what's happen,shlb be return clear of custom msg.